### PR TITLE
add authorship and license info to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 #
+# Written by Rich Felker, originally as part of musl libc.
+# Multi-licensed under MIT, 0BSD, and CC0.
+#
 # This is an actually-safe install command which installs the new
 # file atomically in the new location, rather than overwriting
 # existing files.


### PR DESCRIPTION
MIT license was always offered via musl libc. Also offer
0BSD and CC0 options for projects that prefer it.